### PR TITLE
Add 3D demo notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Motion Sequencing (MoSeq) is an unsupervised machine learning method for animal 
 ## [Documentation](https://keypoint-moseq.readthedocs.io/en/latest/)
 
 - [Colab](https://colab.research.google.com/github/dattalab/keypoint-moseq/blob/main/docs/keypoint_moseq_colab.ipynb)
+- [3D Colab](https://colab.research.google.com/github/dattalab/keypoint-moseq/blob/main/docs/keypoint_moseq_3d_colab.ipynb)
 
 - [Installation](https://keypoint-moseq.readthedocs.io/en/latest/install.html)
 

--- a/docs/keypoint_moseq_3d_colab.ipynb
+++ b/docs/keypoint_moseq_3d_colab.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dae01ab8",
+   "metadata": {},
+   "source": [
+    "# Keypoint-MoSeq 3D Demo\n",
+    "\n",
+    "This notebook demonstrates how to fit a keypoint-MoSeq model to **3D keypoint data**. It assumes you already have triangulated keypoints (e.g. from Anipose or SLEAP-anipose) so no additional reconstruction is required.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e55a9660",
+   "metadata": {},
+   "source": [
+    "## Install and Setup\n",
+    "Run the following cell to install keypoint-MoSeq and mount your Google Drive (if using Colab)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "501eb749",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U keypoint-moseq\n",
+    "import os\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d25b25c",
+   "metadata": {},
+   "source": [
+    "## Project Directory\n",
+    "Specify a directory to store the project configuration and results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d1c6a47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import keypoint_moseq as kpms\n",
+    "\n",
+    "project_dir = '/content/drive/MyDrive/3d_demo_project'\n",
+    "config = lambda: kpms.load_config(project_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb64fe8",
+   "metadata": {},
+   "source": [
+    "### Setup Project\n",
+    "If you already have a config file in `project_dir` just load it. Otherwise run one of the following setup commands. Replace `anipose_file` with the path to one of your 3D keypoint files.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f016e0e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: setup from anipose\n",
+    "# anipose_file = '/path/to/recording.csv'\n",
+    "# kpms.setup_project(project_dir, anipose_file=anipose_file)\n",
+    "\n",
+    "# Example: manual setup\n",
+    "# bodyparts=[...]  # list of keypoint names\n",
+    "# skeleton=[...]   # list of [start, end] pairs\n",
+    "# kpms.setup_project(project_dir, bodyparts=bodyparts, skeleton=skeleton)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0845e0d8",
+   "metadata": {},
+   "source": [
+    "Edit the config as needed. In most cases you will want to set `fps`, `use_bodyparts`, `anterior_bodyparts` and `posterior_bodyparts`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92be6f51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kpms.update_config(project_dir, fps=30)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "754d38ce",
+   "metadata": {},
+   "source": [
+    "## Load 3D keypoint data\n",
+    "Use `kpms.load_keypoints` with the appropriate format. Common choices are `'anipose'` or `'sleap-anipose'`. The path can be a single file, a directory, or a pattern such as `'/path/to/*.h5'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1510580",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keypoint_path = '/content/drive/MyDrive/3d_keypoints/*.h5'\n",
+    "coordinates, confidences, bodyparts = kpms.load_keypoints(keypoint_path, 'sleap-anipose')\n",
+    "\n",
+    "# format for modeling\n",
+    "data, metadata = kpms.format_data(coordinates, confidences, **config())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e00cc1a8",
+   "metadata": {},
+   "source": [
+    "## Outlier Interpolation\n",
+    "Large keypoint outliers can be removed before fitting the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bd0b59d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kpms.update_config(project_dir, outlier_scale_factor=6.0)\n",
+    "for name in coordinates:\n",
+    "    raw = coordinates[name].copy()\n",
+    "    out = kpms.find_medoid_distance_outliers(raw, **config())\n",
+    "    coordinates[name] = kpms.interpolate_keypoints(raw, out['mask'])\n",
+    "    confidences[name] = np.where(out['mask'], 0, confidences[name])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba8c9dc3",
+   "metadata": {},
+   "source": [
+    "## Calibration\n",
+    "Annotate a few frames to calibrate confidence scores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ca7edb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kpms.calibrate_keypoint_confidence(coordinates, confidences, project_dir, **config())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f516ac5d",
+   "metadata": {},
+   "source": [
+    "## Fit Model\n",
+    "First fit an ARHMM for initialization and then fit the full model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62bdfc16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_ar_iters = 50\n",
+    "model, model_name = kpms.fit_model(None, data, metadata, project_dir, ar_only=True, num_iters=num_ar_iters)\n",
+    "\n",
+    "model, data, metadata, current_iter = kpms.load_checkpoint(project_dir, model_name, iteration=num_ar_iters)\n",
+    "model = kpms.update_hypparams(model, kappa=1e4)\n",
+    "model = kpms.fit_model(model, data, metadata, project_dir, model_name, ar_only=False, start_iter=current_iter, num_iters=current_iter+500)[0]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11adc8b3",
+   "metadata": {},
+   "source": [
+    "## Visualization\n",
+    "Plot principal components and trajectories. Grid movies are generated using keypoints only because 3D keypoints cannot be paired with videos directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bebad2f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = kpms.load_results(project_dir, model_name)\n",
+    "kpms.plot_pcs(coordinates, results, project_dir, model_name, **config())\n",
+    "kpms.generate_trajectory_plots(coordinates, results, project_dir, model_name, **config())\n",
+    "kpms.generate_grid_movies(results, project_dir, model_name, coordinates=coordinates, keypoints_only=True, keypoints_scale=1, use_dims=[0,1], **config())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "999a45be",
+   "metadata": {},
+   "source": [
+    "This completes the basic 3D demo. See the FAQ for more details on working with 3D data."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new Colab notebook showing how to run keypoint-moseq with existing 3D keypoints
- link the 3D demo from the README

## Testing
- `jupyter nbconvert --to markdown docs/keypoint_moseq_3d_colab.ipynb --stdout | head -n 12`

------
https://chatgpt.com/codex/tasks/task_e_6880ce2d96088328ac3c5bf049a31abc